### PR TITLE
fix(cmd/handlers) Not skipping a NS if it's declared in the rule

### DIFF
--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -70,7 +70,8 @@ func validateRules(req *v1beta1.AdmissionRequest) []*utils.Violation {
 	json.Unmarshal(raw, &rsc)
 	var violationsSlice []*utils.Violation
 	for _, rule := range rules.GetRules(req.Namespace, req.Kind.Kind) {
-		if utils.Include(skippedNamespaces, req.Namespace) {
+		//Skip rule if namespace is inside SKIP_NAMESPACES environment variable
+		if rule.Namespace == "*" && utils.Include(skippedNamespaces, req.Namespace) {
 			continue
 		}
 		for _, ruledef := range rule.RulesDefinitions {


### PR DESCRIPTION
This PR adds a check to see if the rule is defined to all NS ("*") and NS is in EnvVar SKIP_NAMESPACES and only skip it if it's true.