### PR TITLE
feat(dockerfile) use Go module cache and use scratch for final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM golang:1.15.2-alpine AS builder
 WORKDIR /go/src/github.com/grupozap/aegir
-RUN apk add gcc git make musl-dev tar curl ca-certificates bash
-ADD . .
-RUN go mod tidy
-RUN CGO_ENABLED=0 GOOS=linux go build -o aegir .
-
+RUN apk add --no-cache ca-certificates git
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v
 
 FROM alpine:latest AS dry-app
 RUN mkdir /aegir \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@ COPY go.sum .
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v
+RUN grep nobody /etc/passwd > /etc/passwd.nobody
 
-FROM alpine:latest AS dry-app
-RUN mkdir /aegir \
- &&  mkdir /aegir/tls
-WORKDIR /aegir
-COPY --from=builder /go/src/github.com/grupozap/aegir/aegir .
-ENTRYPOINT ["./aegir"]
+FROM scratch
+COPY --from=builder /etc/passwd.nobody /etc/passwd
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /go/src/github.com/grupozap/aegir/aegir /aegir
+USER nobody
+EXPOSE 8443
+ENTRYPOINT ["/aegir"]

--- a/kube-manifests/aegir.yaml
+++ b/kube-manifests/aegir.yaml
@@ -33,9 +33,9 @@ spec:
         - --rules-file
         - /etc/aegir/rules.yaml
         - --tls-cert-file
-        - /aegir/tls/aegir-cert.crt
+        - /tls/aegir-cert.crt
         - --tls-key-file
-        - /aegir/tls/aegir-key.crt
+        - /tls/aegir-key.crt
         env:
           - name: SKIP_NAMESPACES
             value: "istio-system,kube-system"
@@ -59,7 +59,7 @@ spec:
         - name: aegir-rules
           mountPath: /etc/aegir
         - name: aegir-tls
-          mountPath: /aegir/tls
+          mountPath: /tls
       volumes:
       - name: aegir-rules
         configMap:


### PR DESCRIPTION
These changes adds proper use of the Go module cache during container image build, removes non dependent packages from `apk add`, change the final image base to `scratch` and default user to `nobody` for smaller size and attack surface. Given the move of the binary to the rootfs of the final image, it also updates the sample deployment to mount the TLS secrets into `/tls` to avoid the obvious binary/directory name conflict.